### PR TITLE
Escape values in `field_format` templates

### DIFF
--- a/render/render_html.py
+++ b/render/render_html.py
@@ -291,7 +291,7 @@ class FieldFormatter(string.Formatter):
         val = kwargs.get(key)
         if isinstance(val, dict):
             return DotMap(val)
-        return val
+        return escape(val)
 
 
 class DotMap(dict):
@@ -301,4 +301,4 @@ class DotMap(dict):
         val = self.get(attr)
         if isinstance(val, dict):
             return DotMap(val)
-        return val
+        return escape(val)


### PR DESCRIPTION
These could be used to run XSS attacks if an attacker has control over the parameters in some way, e.g. with the `request.url` parameter used in the example config:
https://github.com/spreadshirt/es-stream-logs/blob/main/config.json#L17-L20

The parameters are now escaped before being sent to the client, which then renders them via `.innerHTML` to allow custom HTML as specified in the config:
https://github.com/spreadshirt/es-stream-logs/blob/main/static/enhance.js#L343-L346