### PR TITLE
Use correct exceptions after elasticsearch-py 8.x update

### DIFF
--- a/es_stream_logs.py
+++ b/es_stream_logs.py
@@ -688,7 +688,7 @@ async def stream_logs(es, renderer, query: Query):
             yield renderer.error(ex, es_query)
             await asyncio.sleep(1)
             continue
-        except elasticsearch.ElasticsearchException as ex:
+        except (elasticsearch.TransportError, elasticsearch.ApiError) as ex:
             print(ex)
             yield renderer.error(ex, es_query)
             return


### PR DESCRIPTION
We missed this in the update, catching both errors is the recommended replacement for the removed `ElasticsearchException`: https://github.com/elastic/elasticsearch-py/blob/f0374b4b6eded41faef46e63e8dacf116c8a1026/docs/guide/migration.asciidoc#changes-to-error-classes

We do already handle `ConnectionTimeout` separately with a retry, so it's fine to handle both TransportError and ApiError as one thing.

Before the fix the following error was logged in case an exception was raised in this block:

```
    except elasticsearch.ElasticsearchException as ex:
AttributeError: module 'elasticsearch' has no attribute 'ElasticsearchException'
```