### PR TITLE
Allow multiple elasticsearch hosts

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,10 +1,10 @@
 {
   "default_endpoint": "local",
   "endpoints": {
-    "local": {"url": "http://localhost:9200"},
-    "dc3": {"url": "https://elasticsearch-dc3.example.com:443"},
-    "dc1": {"url": "https://elasticsearch-dc1.example.com:443"},
-    "dc2": {"url": "https://elasticsearch-dc2.example.com:443"}
+    "local": ["http://localhost:9200", "http://localhost:9201"],
+    "dc3": ["https://elasticsearch-dc3.example.com:443"],
+    "dc1": ["https://elasticsearch-dc1.example.com:443"],
+    "dc2": ["https://elasticsearch-dc2.example.com:443"]
   },
   "indices": [
     "application-*",

--- a/config.py
+++ b/config.py
@@ -6,13 +6,6 @@ from typing import Dict, List
 
 
 @dataclass
-class Endpoint:
-    """ Configuration for an elasticsearch endpoint. """
-
-    url: str
-
-
-@dataclass
 class DefaultFields:
     """ Configuration for default fields. """
 
@@ -33,7 +26,7 @@ class Config:
     """ Encapsulates configuration, e.g. datacenters. """
 
     default_endpoint: str
-    endpoints: Dict[str, Endpoint]
+    endpoints: Dict[str, List[str]]
     indices: List[str]
 
     field_format: Dict[str, str]
@@ -42,8 +35,6 @@ class Config:
     queries: List[str]
 
     def __post_init__(self):
-        for key in self.endpoints:
-            self.endpoints[key] = Endpoint(**self.endpoints[key])
         self.default_fields = [DefaultFields(**df) for df in self.default_fields]
 
     def find_default_fields(self, **kwargs):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,10 @@
 version: '3'
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
     environment:
       discovery.type: single-node
+      xpack.security.enabled: "false"
     ports:
       - "9200:9200"
   ui:

--- a/es_stream_logs.py
+++ b/es_stream_logs.py
@@ -824,7 +824,7 @@ async def es_client_from(request: Request):
     if datacenter not in config.endpoints:
         return None, Response(status_code=400, content=f"unknown datacenter '{datacenter}'")
 
-    es_client = AsyncElasticsearch([config.endpoints[datacenter].url],
+    es_client = AsyncElasticsearch(config.endpoints[datacenter],
                                    http_auth=(username, password),
                                    http_compress=True)
 


### PR DESCRIPTION
The ElasticSearch clients have always allowed this, but we haven't used it.
This is more flexible and should work in more situations.

This is a **breaking change** to the config, but as the API and everything
else is still the same this will be released as a minor update.  (We would
have the option to support both syntaxes, but the config is easy to change
so that seems like unnecessary complexity, especially with the... small
number of users of this project that exist.)

Tested this locally with the `docker compose` setup.  `http://localhost:9201` does
not exist but the `elasticsearch` library correctly works around that.