### PR TITLE
Fix emoji (to use some that actually exist)

### DIFF
--- a/static/enhance.js
+++ b/static/enhance.js
@@ -320,7 +320,7 @@ function renderSourceTable(source, formattedFields) {
                 "href": addFilter(key, value, true),
             }, "🗑"));
             buttons.appendChild(makeElement("a", {
-                "title": "Add field",
+                "title": "Display field in table",
                 "classList": "filter2",
                 "href": addField(key),
             }, "✶"));

--- a/static/enhance.js
+++ b/static/enhance.js
@@ -50,7 +50,7 @@ window.addEventListener("DOMContentLoaded", function() {
 
 var histogramLinks = document.querySelector("#histogram_links");
 var markdownButton = document.createElement("a");
-markdownButton.textContent = "🗍";
+markdownButton.textContent = "📄";
 markdownButton.title = "copy as markdown";
 markdownButton.href = "#";
 markdownButton.onclick = function(ev) {
@@ -323,12 +323,12 @@ function renderSourceTable(source, formattedFields) {
                 "title": "Add field",
                 "classList": "filter2",
                 "href": addField(key),
-            }, "🗍"));
+            }, "✶"));
             buttons.appendChild(makeElement("a", {
                 "title": "Require field to be present",
                 "classList": "filter2",
                 "href": requireField(key),
-            }, "🞸"));
+            }, "❗"));
             buttons.appendChild(makeElement("input", {
                 "title": "Add query for this field",
                 "type": "checkbox",


### PR DESCRIPTION
The emojis for "add column to table", exist filter and "copy as markdown" were all broken, either because they only used to work on specific systems (e.g. mine probably) or because they got broken at some point via copy-paste, maybe while open-sourcing.

Now they are fixed and use actual emoji again.