### PR TITLE
Fix histogram when there are larger differences in document count

### DIFF
--- a/es_stream_logs.py
+++ b/es_stream_logs.py
@@ -365,7 +365,7 @@ async def aggregation_svg(es, request: Request, query: Query):
             "key": bucket['key_as_string'],
             "label_y": "15%" if is_internal else "50%",
             "label_align": label_align,
-            "height": int((count / max_count) * 100),
+            "height": max(0.25, int((count / max_count) * 100)) if count > 0 else 0,
             "pos_x": scale.map(bucket['key']),
             "from_ts": from_ts,
             "to_ts": to_ts,


### PR DESCRIPTION
The large difference would cause histogram boxes not to be rendered when the counts were very different, very likely due to rounding issues.

A similar fix was already in place when `aggregation_terms` was used, but not for regular queries.

Before:

![2024-09-23T17:29:35,762483331+02:00](https://github.com/user-attachments/assets/6b7c6bbc-0ea0-4463-8b36-ebdd08d58375)

After (note the tiny boxes after the big spike):

![2024-09-23T17:29:10,423599121+02:00](https://github.com/user-attachments/assets/4131b635-1d0b-407c-ac9a-41ead22d13f2)

And for completeness, with `&aggregation_terms=level` (same as before):

![2024-09-23T17:43:30,656994521+02:00](https://github.com/user-attachments/assets/ea72002b-edb8-4900-904f-12b87443f99b)

